### PR TITLE
hardcode fix for bugg due to latest dalton on triolith intel/mpi/impi

### DIFF
--- a/sirifc.py
+++ b/sirifc.py
@@ -23,6 +23,8 @@ class sirifc(unformatted.FortranBinary):
            self.INT = 'q'
         elif self.reclen == 48:
            self.INT = 'i'
+        elif self.reclen == 52:
+           self.INT = 'i'
 	else:
            raise Exception('Unconsistent first record in SIRIFC')
 


### PR DESCRIPTION
Latest DALTON on triolith causes reading errors in this section.

I really don't know why this works but it does.

Extra dalton compilation cmake variables:

DALTON compilation information:
C++= /software/apps/intel/impi/5.0.2.044/intel64/bin/mpiicpc
C= /software/apps/intel/impi/5.0.2.044/intel64/bin/mpiicc
FORTRAN= /software/apps/intel/impi/5.0.2.044/intel64/bin/mpiifort
ENABLE_64BIT_INTEGERS:BOOL=OFF
