### PR TITLE
Title length changed in dalton master

### DIFF
--- a/daltools/one.py
+++ b/daltools/one.py
@@ -12,7 +12,7 @@ def readhead(filename="AOONEINT"):
     """Read data in header of AOONEINT"""
     aooneint = FortranBinary(filename)
     rec = next(aooneint)
-    if len(aooneint.data) == 144:
+    if len(aooneint.data) in (144, 400):
         #
         # Newer versions: title in own record
         #


### PR DESCRIPTION
The length of the title line was changed from 72 to 200 characters in https://gitlab.com/dalton/dalton/-/merge_requests/362 which was merged to dalton/master.
This also changes the length of the record on `AOONEINT`.

